### PR TITLE
test: cover scan-time provider, download limit, and save rollback

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,3 +32,18 @@ updates:
       jellyfin-packages:
         patterns:
           - "Jellyfin.*"
+
+  # Test project is not reachable from the root csproj (tests reference it, not
+  # the other way around) and there is no solution file, so it needs its own entry
+  - package-ecosystem: "nuget"
+    directory: "/tests/Jellyfin.Plugin.ImdbRatings.Tests"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "nuget"
+    commit-message:
+      prefix: "chore"
+      include: "scope"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,12 @@ dotnet format whitespace --verify-no-changes
 dotnet format style --verify-no-changes --severity warn
 ```
 
+## Badges
+
+The `coverage-N%` badge is maintained by hand from the `line-rate` that `dotnet test --collect:"XPlat Code Coverage"` writes to its Cobertura report, rounded to a whole percent.
+
+The `dependencies-N outdated` badge in the README is maintained by hand: `N` is the row count from `dotnet list package --outdated` across both `Jellyfin.Plugin.ImdbRatings.csproj` and the test project, excluding the `Jellyfin.*` packages that are intentionally pinned for server backwards compatibility, so bump it whenever you change a `PackageReference`.
+
 ## Reporting Issues
 
 - Search existing issues before opening a new one

--- a/Providers/ImdbRatingsItemProvider.cs
+++ b/Providers/ImdbRatingsItemProvider.cs
@@ -65,15 +65,25 @@ public class ImdbRatingsItemProvider :
 
     /// <inheritdoc />
     public Task<ItemUpdateType> FetchAsync(Movie item, MetadataRefreshOptions options, CancellationToken cancellationToken)
-        => ApplyRatingAsync(item, config => config.IncludeMovies, cancellationToken);
+        => ApplyRatingAsync(item, IsMovieEnabled, cancellationToken);
 
     /// <inheritdoc />
     public Task<ItemUpdateType> FetchAsync(Series item, MetadataRefreshOptions options, CancellationToken cancellationToken)
-        => ApplyRatingAsync(item, config => config.IncludeSeries, cancellationToken);
+        => ApplyRatingAsync(item, IsSeriesEnabled, cancellationToken);
 
     /// <inheritdoc />
     public Task<ItemUpdateType> FetchAsync(Episode item, MetadataRefreshOptions options, CancellationToken cancellationToken)
-        => ApplyRatingAsync(item, config => config.IncludeSeries, cancellationToken);
+        => ApplyRatingAsync(item, IsSeriesEnabled, cancellationToken);
+
+    /// <summary>
+    /// Gets whether movies are enabled. Named rather than inline so the item-type-to-setting mapping is testable.
+    /// </summary>
+    internal static bool IsMovieEnabled(PluginConfiguration config) => config.IncludeMovies;
+
+    /// <summary>
+    /// Gets whether series and episodes are enabled; both follow the single Include Series setting.
+    /// </summary>
+    internal static bool IsSeriesEnabled(PluginConfiguration config) => config.IncludeSeries;
 
     private async Task<ItemUpdateType> ApplyRatingAsync(
         BaseItem item,
@@ -99,14 +109,41 @@ public class ImdbRatingsItemProvider :
             return ItemUpdateType.None;
         }
 
-        var imdbId = item.GetProviderId(MetadataProvider.Imdb);
-        if (string.IsNullOrWhiteSpace(imdbId))
+        // Loading the index is the one expensive step, so skip it for items that cannot use it anyway.
+        if (string.IsNullOrWhiteSpace(item.GetProviderId(MetadataProvider.Imdb)))
         {
             return ItemUpdateType.None;
         }
 
         var index = await _indexCache.GetIndexAsync(cancellationToken).ConfigureAwait(false);
-        if (index is null)
+
+        return Apply(item, config, typeEnabled: true, index, _logger);
+    }
+
+    /// <summary>
+    /// Decides and applies the rating for a single item, given an already-resolved configuration and index.
+    /// </summary>
+    /// <remarks>
+    /// Split out from <see cref="ApplyRatingAsync"/> so the decision ladder can be tested without a
+    /// <see cref="Plugin"/> singleton, a Jellyfin server, or an index cache behind it.
+    /// </remarks>
+    internal static ItemUpdateType Apply(
+        BaseItem item,
+        PluginConfiguration config,
+        bool typeEnabled,
+        ImdbRatingsIndex? index,
+        ILogger logger)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+        ArgumentNullException.ThrowIfNull(config);
+
+        if (!config.EnableMetadataProvider || !typeEnabled || index is null)
+        {
+            return ItemUpdateType.None;
+        }
+
+        var imdbId = item.GetProviderId(MetadataProvider.Imdb);
+        if (string.IsNullOrWhiteSpace(imdbId))
         {
             return ItemUpdateType.None;
         }
@@ -116,15 +153,15 @@ public class ImdbRatingsItemProvider :
             return ItemUpdateType.None;
         }
 
-        // Match the scheduled task's tolerance so the two paths agree on what counts as a change.
-        if (item.CommunityRating.HasValue && Math.Abs(item.CommunityRating.Value - rating) < 0.01f)
+        // Shared with the scheduled task so the two paths agree on what counts as a change.
+        if (RatingComparison.IsUnchanged(item.CommunityRating, rating))
         {
             return ItemUpdateType.None;
         }
 
-        if (config.EnableItemDebugLogging && _logger.IsEnabled(LogLevel.Debug))
+        if (config.EnableItemDebugLogging && logger.IsEnabled(LogLevel.Debug))
         {
-            _logger.LogDebug(
+            logger.LogDebug(
                 "Applying IMDb rating {Rating} ({Votes} votes) to \"{Name}\" ({ImdbId}) at scan time",
                 rating,
                 votes,

--- a/Providers/RatingComparison.cs
+++ b/Providers/RatingComparison.cs
@@ -1,0 +1,28 @@
+namespace Jellyfin.Plugin.ImdbRatings.Providers;
+
+/// <summary>
+/// Shared policy for deciding whether an IMDb rating differs enough from an item's current
+/// <c>CommunityRating</c> to be worth persisting.
+/// </summary>
+/// <remarks>
+/// The scheduled task and the scan-time metadata provider both make this decision, and they must agree:
+/// if one treats a value as changed while the other treats it as unchanged, an item's rating flips back and
+/// forth between the two paths on every refresh. This lives in one place so the tolerance cannot drift.
+/// </remarks>
+public static class RatingComparison
+{
+    /// <summary>
+    /// Ratings closer together than this are treated as equal. IMDb publishes one decimal place, so anything
+    /// below 0.1 is comfortably tighter than the smallest real change while absorbing float round-tripping.
+    /// </summary>
+    public const float Tolerance = 0.01f;
+
+    /// <summary>
+    /// Returns true when <paramref name="current"/> already holds <paramref name="candidate"/>.
+    /// An item with no rating is always considered changed.
+    /// </summary>
+    public static bool IsUnchanged(float? current, float candidate)
+    {
+        return current.HasValue && System.Math.Abs(current.Value - candidate) < Tolerance;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
     <img src="https://img.shields.io/github/v/release/voc0der/jellyfin-imdb-rating-updater?label=stable%20release" alt="Stable release version" />
   </a>
   <a href="https://github.com/voc0der/jellyfin-imdb-rating-updater/tree/main/tests">
-    <img src="https://img.shields.io/badge/coverage-26%25-red" alt="Code coverage percentage" />
+    <img src="https://img.shields.io/badge/coverage-65%25-yellow" alt="Code coverage percentage" />
   </a>
   <a href="https://github.com/voc0der/jellyfin-imdb-rating-updater/issues">
     <img src="https://img.shields.io/github/issues/voc0der/jellyfin-imdb-rating-updater?color=DAA520" alt="Open issues" />
@@ -17,7 +17,7 @@
   <a href="LICENSE">
     <img src="https://img.shields.io/github/license/voc0der/jellyfin-imdb-rating-updater?color=97CA00" alt="License" />
   </a>
-  <a href="https://github.com/voc0der/jellyfin-imdb-rating-updater/blob/main/tests/Jellyfin.Plugin.ImdbRatings.Tests/Jellyfin.Plugin.ImdbRatings.Tests.csproj">
+  <a href="https://github.com/voc0der/jellyfin-imdb-rating-updater/network/dependencies">
     <img src="https://img.shields.io/badge/dependencies-4%20outdated-orange" alt="Dependencies status" />
   </a>
 </p>

--- a/ScheduledTasks/RefreshImdbRatingsTask.cs
+++ b/ScheduledTasks/RefreshImdbRatingsTask.cs
@@ -128,7 +128,7 @@ public class RefreshImdbRatingsTask : IScheduledTask
         int lastScanProgressBucket = 30;
 
         // Step 4: Identify items that need rating updates (without mutating in-memory state)
-        var pendingUpdates = new List<(BaseItem Item, BaseItem? Parent, float? OldRating, float NewRating)>();
+        var pendingUpdates = new List<PendingRatingUpdate>();
         int skippedMissingImdbId = 0;
         int skippedBelowMinimumVotes = 0;
         int skippedUnchanged = 0;
@@ -170,13 +170,13 @@ public class RefreshImdbRatingsTask : IScheduledTask
             else
             {
                 var newRating = ratingData.Rating;
-                if (item.CommunityRating.HasValue && Math.Abs(item.CommunityRating.Value - newRating) < 0.01f)
+                if (RatingComparison.IsUnchanged(item.CommunityRating, newRating))
                 {
                     skippedUnchanged++;
                 }
                 else
                 {
-                    pendingUpdates.Add((item, item.GetParent(), item.CommunityRating, newRating));
+                    pendingUpdates.Add(new PendingRatingUpdate(item, item.GetParent(), item.CommunityRating, newRating));
                 }
             }
 
@@ -243,13 +243,13 @@ public class RefreshImdbRatingsTask : IScheduledTask
                     continue;
                 }
 
-                if (season.CommunityRating.HasValue && Math.Abs(season.CommunityRating.Value - avgRating) < 0.01f)
+                if (RatingComparison.IsUnchanged(season.CommunityRating, avgRating))
                 {
                     seasonSkippedUnchanged++;
                     continue;
                 }
 
-                pendingUpdates.Add((season, season.GetParent(), season.CommunityRating, avgRating));
+                pendingUpdates.Add(new PendingRatingUpdate(season, season.GetParent(), season.CommunityRating, avgRating));
                 seasonUpdated++;
             }
 
@@ -267,77 +267,11 @@ public class RefreshImdbRatingsTask : IScheduledTask
         {
             _logger.LogInformation("Batch saving {Count} updated ratings to database", pendingUpdates.Count);
 
-            const int batchSize = 500;
-            var byParent = pendingUpdates.GroupBy(p => p.Parent?.Id ?? Guid.Empty);
-            int saved = 0;
-            int lastSaveProgressBucket = 90;
-
-            foreach (var group in byParent)
-            {
-                var parent = group.First().Parent;
-
-                foreach (var chunk in group.Chunk(batchSize))
-                {
-                    cancellationToken.ThrowIfCancellationRequested();
-
-                    if (parent is null)
-                    {
-                        // Preserve prior semantics for root/null-parent items.
-                        for (int j = 0; j < chunk.Length; j++)
-                        {
-                            chunk[j].Item.CommunityRating = chunk[j].NewRating;
-                            try
-                            {
-                                await _libraryManager.UpdateItemAsync(
-                                    chunk[j].Item,
-                                    chunk[j].Parent!, // Preserve prior behavior for root items with no parent.
-                                    ItemUpdateType.MetadataEdit,
-                                    cancellationToken).ConfigureAwait(false);
-                            }
-                            catch
-                            {
-                                chunk[j].Item.CommunityRating = chunk[j].OldRating;
-                                throw;
-                            }
-                        }
-                    }
-                    else
-                    {
-                        // Apply ratings immediately before persisting this chunk.
-                        var chunkItems = new BaseItem[chunk.Length];
-                        for (int j = 0; j < chunk.Length; j++)
-                        {
-                            chunk[j].Item.CommunityRating = chunk[j].NewRating;
-                            chunkItems[j] = chunk[j].Item;
-                        }
-
-                        try
-                        {
-                            await _libraryManager.UpdateItemsAsync(chunkItems, parent, ItemUpdateType.MetadataEdit, cancellationToken).ConfigureAwait(false);
-                        }
-                        catch
-                        {
-                            // Revert this chunk's in-memory mutations if the batch save fails/cancels.
-                            for (int j = 0; j < chunk.Length; j++)
-                            {
-                                chunk[j].Item.CommunityRating = chunk[j].OldRating;
-                            }
-
-                            throw;
-                        }
-                    }
-
-                    saved += chunk.Length;
-
-                    double saveProgress = 90 + (10.0 * saved / pendingUpdates.Count);
-                    int saveProgressBucket = (int)saveProgress;
-                    if (saveProgressBucket > lastSaveProgressBucket)
-                    {
-                        lastSaveProgressBucket = saveProgressBucket;
-                        progress.Report(saveProgress);
-                    }
-                }
-            }
+            await ApplyPendingUpdatesAsync(
+                pendingUpdates,
+                new LibraryManagerUpdateSink(_libraryManager),
+                progress,
+                cancellationToken).ConfigureAwait(false);
         }
 
         // Step 6: Refresh the compact index the scan-time metadata provider reads.
@@ -354,6 +288,119 @@ public class RefreshImdbRatingsTask : IScheduledTask
             skippedBelowMinimumVotes,
             skippedMissingImdbId,
             notFound);
+    }
+
+    /// <summary>
+    /// Applies each pending rating and persists it, grouped by parent and chunked.
+    /// </summary>
+    /// <remarks>
+    /// Ratings are written to the in-memory items only immediately before the chunk containing them is saved,
+    /// and reverted if that save throws. Jellyfin hands out live <see cref="BaseItem"/> instances, so a chunk
+    /// that failed to persist must not leave the running server displaying a rating no database row holds.
+    /// </remarks>
+    internal static async Task ApplyPendingUpdatesAsync(
+        IReadOnlyList<PendingRatingUpdate> pendingUpdates,
+        IItemUpdateSink sink,
+        IProgress<double> progress,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(pendingUpdates);
+        ArgumentNullException.ThrowIfNull(sink);
+        ArgumentNullException.ThrowIfNull(progress);
+
+        const int batchSize = 500;
+        var byParent = pendingUpdates.GroupBy(p => p.Parent?.Id ?? Guid.Empty);
+        int saved = 0;
+        int lastSaveProgressBucket = 90;
+
+        foreach (var group in byParent)
+        {
+            var parent = group.First().Parent;
+
+            foreach (var chunk in group.Chunk(batchSize))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (parent is null)
+                {
+                    // Preserve prior semantics for root/null-parent items.
+                    for (int j = 0; j < chunk.Length; j++)
+                    {
+                        chunk[j].Item.CommunityRating = chunk[j].NewRating;
+                        try
+                        {
+                            await sink.UpdateItemAsync(
+                                chunk[j].Item,
+                                chunk[j].Parent, // Preserve prior behavior for root items with no parent.
+                                ItemUpdateType.MetadataEdit,
+                                cancellationToken).ConfigureAwait(false);
+                        }
+                        catch
+                        {
+                            chunk[j].Item.CommunityRating = chunk[j].OldRating;
+                            throw;
+                        }
+                    }
+                }
+                else
+                {
+                    // Apply ratings immediately before persisting this chunk.
+                    var chunkItems = new BaseItem[chunk.Length];
+                    for (int j = 0; j < chunk.Length; j++)
+                    {
+                        chunk[j].Item.CommunityRating = chunk[j].NewRating;
+                        chunkItems[j] = chunk[j].Item;
+                    }
+
+                    try
+                    {
+                        await sink.UpdateItemsAsync(chunkItems, parent, ItemUpdateType.MetadataEdit, cancellationToken).ConfigureAwait(false);
+                    }
+                    catch
+                    {
+                        // Revert this chunk's in-memory mutations if the batch save fails/cancels.
+                        for (int j = 0; j < chunk.Length; j++)
+                        {
+                            chunk[j].Item.CommunityRating = chunk[j].OldRating;
+                        }
+
+                        throw;
+                    }
+                }
+
+                saved += chunk.Length;
+
+                double saveProgress = 90 + (10.0 * saved / pendingUpdates.Count);
+                int saveProgressBucket = (int)saveProgress;
+                if (saveProgressBucket > lastSaveProgressBucket)
+                {
+                    lastSaveProgressBucket = saveProgressBucket;
+                    progress.Report(saveProgress);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Builds the <see cref="BaseItemKind"/> filter for the library query, empty when nothing is selected.
+    /// </summary>
+    internal static BaseItemKind[] BuildIncludeItemTypes(PluginConfiguration config)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+
+        var includeTypes = new List<BaseItemKind>();
+        if (config.IncludeMovies)
+        {
+            includeTypes.Add(BaseItemKind.Movie);
+        }
+
+        if (config.IncludeSeries)
+        {
+            includeTypes.Add(BaseItemKind.Series);
+            includeTypes.Add(BaseItemKind.Episode);
+        }
+
+        return includeTypes.ToArray();
     }
 
     /// <summary>
@@ -576,26 +623,47 @@ public class RefreshImdbRatingsTask : IScheduledTask
             Recursive = true
         };
 
-        var includeTypes = new List<BaseItemKind>();
-        if (config.IncludeMovies)
-        {
-            includeTypes.Add(BaseItemKind.Movie);
-        }
-
-        if (config.IncludeSeries)
-        {
-            includeTypes.Add(BaseItemKind.Series);
-            includeTypes.Add(BaseItemKind.Episode);
-        }
-
-        if (includeTypes.Count == 0)
+        var includeTypes = BuildIncludeItemTypes(config);
+        if (includeTypes.Length == 0)
         {
             _logger.LogWarning("No library types selected — nothing to update");
             return Array.Empty<BaseItem>();
         }
 
-        query.IncludeItemTypes = includeTypes.ToArray();
+        query.IncludeItemTypes = includeTypes;
 
         return _libraryManager.GetItemList(query);
+    }
+
+    /// <summary>
+    /// The subset of <see cref="ILibraryManager"/> the batch-save loop needs, so the loop is testable
+    /// without standing up the full 100-method interface.
+    /// </summary>
+    internal interface IItemUpdateSink
+    {
+        Task UpdateItemAsync(BaseItem item, BaseItem? parent, ItemUpdateType updateReason, CancellationToken cancellationToken);
+
+        Task UpdateItemsAsync(IReadOnlyList<BaseItem> items, BaseItem parent, ItemUpdateType updateReason, CancellationToken cancellationToken);
+    }
+
+    /// <summary>
+    /// A single rating change, captured before anything is mutated so a failed save can be undone.
+    /// </summary>
+    internal readonly record struct PendingRatingUpdate(BaseItem Item, BaseItem? Parent, float? OldRating, float NewRating);
+
+    private sealed class LibraryManagerUpdateSink : IItemUpdateSink
+    {
+        private readonly ILibraryManager _libraryManager;
+
+        public LibraryManagerUpdateSink(ILibraryManager libraryManager)
+        {
+            _libraryManager = libraryManager;
+        }
+
+        public Task UpdateItemAsync(BaseItem item, BaseItem? parent, ItemUpdateType updateReason, CancellationToken cancellationToken)
+            => _libraryManager.UpdateItemAsync(item, parent!, updateReason, cancellationToken);
+
+        public Task UpdateItemsAsync(IReadOnlyList<BaseItem> items, BaseItem parent, ItemUpdateType updateReason, CancellationToken cancellationToken)
+            => _libraryManager.UpdateItemsAsync(items, parent, updateReason, cancellationToken);
     }
 }

--- a/tests/Jellyfin.Plugin.ImdbRatings.Tests/ImdbFlatFileDownloaderTests.cs
+++ b/tests/Jellyfin.Plugin.ImdbRatings.Tests/ImdbFlatFileDownloaderTests.cs
@@ -1,0 +1,272 @@
+using System.IO.Compression;
+using System.Net;
+using Jellyfin.Plugin.ImdbRatings.Providers;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Jellyfin.Plugin.ImdbRatings.Tests;
+
+/// <summary>
+/// Covers the download/cache layer, including the decompressed-size limit that stops a hostile or corrupt
+/// gzip response from filling the server's disk.
+/// </summary>
+public class ImdbFlatFileDownloaderTests
+{
+    // Mirrors ImdbFlatFileDownloader.MaxDecompressedSize.
+    private const long MaxDecompressedSize = 100 * 1024 * 1024;
+
+    // Mirrors ImdbFlatFileDownloader.CacheMaxAge.
+    private static readonly TimeSpan CacheMaxAge = TimeSpan.FromHours(23);
+
+    [Fact]
+    public async Task GetRatingsFilePathAsync_NoCache_DownloadsAndDecompresses()
+    {
+        using var temp = new TempDirectory();
+        const string payload = "tconst\taverageRating\tnumVotes\ntt0000001\t7.5\t100\n";
+        var handler = new StubHandler(GzipOf(payload));
+        var downloader = new ImdbFlatFileDownloader(new StubHttpClientFactory(handler), NullLogger<ImdbFlatFileDownloader>.Instance, temp.Path);
+
+        var path = await downloader.GetRatingsFilePathAsync(CancellationToken.None);
+
+        Assert.Equal(downloader.CachePath, path);
+        Assert.Equal(payload, await File.ReadAllTextAsync(path));
+        Assert.Equal(1, handler.RequestCount);
+        Assert.False(File.Exists(path + ".tmp"));
+    }
+
+    [Fact]
+    public async Task GetRatingsFilePathAsync_DecompressedPayloadExceedsLimit_ThrowsAndLeavesNoFiles()
+    {
+        using var temp = new TempDirectory();
+        var handler = new StubHandler(GzipOfZeroBytes(MaxDecompressedSize + (1024 * 1024)));
+        var downloader = new ImdbFlatFileDownloader(new StubHttpClientFactory(handler), NullLogger<ImdbFlatFileDownloader>.Instance, temp.Path);
+
+        var ex = await Assert.ThrowsAsync<InvalidDataException>(
+            () => downloader.GetRatingsFilePathAsync(CancellationToken.None));
+
+        Assert.Contains("100 MB", ex.Message, StringComparison.Ordinal);
+
+        // The partial write must not survive as either a temp file or a usable cache.
+        Assert.False(File.Exists(downloader.CachePath + ".tmp"));
+        Assert.False(File.Exists(downloader.CachePath));
+        Assert.False(downloader.HasCacheFile);
+    }
+
+    [Fact]
+    public async Task GetRatingsFilePathAsync_OversizedPayload_LeavesPreviousCacheIntact()
+    {
+        using var temp = new TempDirectory();
+        var handler = new StubHandler(GzipOfZeroBytes(MaxDecompressedSize + (1024 * 1024)));
+        var downloader = new ImdbFlatFileDownloader(new StubHttpClientFactory(handler), NullLogger<ImdbFlatFileDownloader>.Instance, temp.Path);
+
+        // A stale but valid cache from a previous run.
+        Directory.CreateDirectory(Path.GetDirectoryName(downloader.CachePath)!);
+        await File.WriteAllTextAsync(downloader.CachePath, "previous good data");
+        File.SetLastWriteTimeUtc(downloader.CachePath, DateTime.UtcNow - CacheMaxAge - TimeSpan.FromHours(1));
+
+        await Assert.ThrowsAsync<InvalidDataException>(
+            () => downloader.GetRatingsFilePathAsync(CancellationToken.None));
+
+        Assert.Equal("previous good data", await File.ReadAllTextAsync(downloader.CachePath));
+    }
+
+    [Fact]
+    public async Task GetRatingsFilePathAsync_HttpError_ThrowsAndWritesNothing()
+    {
+        using var temp = new TempDirectory();
+        var handler = new StubHandler(Array.Empty<byte>(), HttpStatusCode.ServiceUnavailable);
+        var downloader = new ImdbFlatFileDownloader(new StubHttpClientFactory(handler), NullLogger<ImdbFlatFileDownloader>.Instance, temp.Path);
+
+        await Assert.ThrowsAsync<HttpRequestException>(
+            () => downloader.GetRatingsFilePathAsync(CancellationToken.None));
+
+        Assert.False(File.Exists(downloader.CachePath));
+        Assert.False(File.Exists(downloader.CachePath + ".tmp"));
+    }
+
+    [Fact]
+    public async Task GetRatingsFilePathAsync_NotGzipAtAll_ThrowsAndCleansUpTempFile()
+    {
+        using var temp = new TempDirectory();
+        var handler = new StubHandler(System.Text.Encoding.UTF8.GetBytes("<html>502 Bad Gateway</html>"));
+        var downloader = new ImdbFlatFileDownloader(new StubHttpClientFactory(handler), NullLogger<ImdbFlatFileDownloader>.Instance, temp.Path);
+
+        await Assert.ThrowsAsync<InvalidDataException>(() => downloader.GetRatingsFilePathAsync(CancellationToken.None));
+
+        Assert.False(File.Exists(downloader.CachePath + ".tmp"));
+        Assert.False(File.Exists(downloader.CachePath));
+    }
+
+    [Fact]
+    public async Task GetRatingsFilePathAsync_TruncatedGzipHeader_WritesEmptyCacheForTheParserToReject()
+    {
+        // GZipStream treats a stream that ends inside the header as a clean end-of-data rather than an error,
+        // so this path produces an empty cache file instead of throwing. That is caught one layer up: the
+        // parser rejects a file with no header, and the task then invalidates the cache and re-downloads.
+        using var temp = new TempDirectory();
+        var handler = new StubHandler(new byte[] { 0x1f, 0x8b, 0x08, 0x00, 0xde, 0xad, 0xbe, 0xef });
+        var downloader = new ImdbFlatFileDownloader(new StubHttpClientFactory(handler), NullLogger<ImdbFlatFileDownloader>.Instance, temp.Path);
+
+        var path = await downloader.GetRatingsFilePathAsync(CancellationToken.None);
+
+        Assert.Empty(await File.ReadAllBytesAsync(path));
+        Assert.False(File.Exists(downloader.CachePath + ".tmp"));
+
+        var parser = new ImdbRatingsParser(NullLogger<ImdbRatingsParser>.Instance);
+        await Assert.ThrowsAsync<InvalidDataException>(
+            () => parser.ParseAsync(path, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task GetRatingsFilePathAsync_FreshCache_SkipsDownloadEntirely()
+    {
+        using var temp = new TempDirectory();
+        var handler = new StubHandler(GzipOf("should not be requested"));
+        var downloader = new ImdbFlatFileDownloader(new StubHttpClientFactory(handler), NullLogger<ImdbFlatFileDownloader>.Instance, temp.Path);
+
+        Directory.CreateDirectory(Path.GetDirectoryName(downloader.CachePath)!);
+        await File.WriteAllTextAsync(downloader.CachePath, "cached");
+        File.SetLastWriteTimeUtc(downloader.CachePath, DateTime.UtcNow - CacheMaxAge + TimeSpan.FromMinutes(30));
+
+        var path = await downloader.GetRatingsFilePathAsync(CancellationToken.None);
+
+        Assert.Equal("cached", await File.ReadAllTextAsync(path));
+        Assert.Equal(0, handler.RequestCount);
+    }
+
+    [Fact]
+    public async Task GetRatingsFilePathAsync_CacheOlderThanMaxAge_RedownloadsAndReplaces()
+    {
+        using var temp = new TempDirectory();
+        var handler = new StubHandler(GzipOf("fresh data"));
+        var downloader = new ImdbFlatFileDownloader(new StubHttpClientFactory(handler), NullLogger<ImdbFlatFileDownloader>.Instance, temp.Path);
+
+        Directory.CreateDirectory(Path.GetDirectoryName(downloader.CachePath)!);
+        await File.WriteAllTextAsync(downloader.CachePath, "stale data");
+        File.SetLastWriteTimeUtc(downloader.CachePath, DateTime.UtcNow - CacheMaxAge - TimeSpan.FromMinutes(1));
+
+        var path = await downloader.GetRatingsFilePathAsync(CancellationToken.None);
+
+        Assert.Equal("fresh data", await File.ReadAllTextAsync(path));
+        Assert.Equal(1, handler.RequestCount);
+    }
+
+    [Fact]
+    public async Task InvalidateCache_RemovesBothCacheAndStaleTempFile()
+    {
+        using var temp = new TempDirectory();
+        var downloader = new ImdbFlatFileDownloader(
+            new StubHttpClientFactory(new StubHandler(Array.Empty<byte>())), NullLogger<ImdbFlatFileDownloader>.Instance, temp.Path);
+
+        Directory.CreateDirectory(Path.GetDirectoryName(downloader.CachePath)!);
+        await File.WriteAllTextAsync(downloader.CachePath, "cached");
+        await File.WriteAllTextAsync(downloader.CachePath + ".tmp", "leftover from a failed run");
+
+        Assert.True(downloader.InvalidateCache());
+
+        Assert.False(File.Exists(downloader.CachePath));
+        Assert.False(File.Exists(downloader.CachePath + ".tmp"));
+    }
+
+    [Fact]
+    public void InvalidateCache_NothingCached_ReturnsFalse()
+    {
+        using var temp = new TempDirectory();
+        var downloader = new ImdbFlatFileDownloader(
+            new StubHttpClientFactory(new StubHandler(Array.Empty<byte>())), NullLogger<ImdbFlatFileDownloader>.Instance, temp.Path);
+
+        Assert.False(downloader.InvalidateCache());
+        Assert.False(downloader.HasCacheFile);
+    }
+
+    [Fact]
+    public void CachePath_SitsBesideTheProviderIndex()
+    {
+        using var temp = new TempDirectory();
+        var downloader = new ImdbFlatFileDownloader(
+            new StubHttpClientFactory(new StubHandler(Array.Empty<byte>())), NullLogger<ImdbFlatFileDownloader>.Instance, temp.Path);
+
+        Assert.Equal(
+            Path.GetDirectoryName(ImdbRatingsIndex.GetIndexPath(temp.Path)),
+            Path.GetDirectoryName(downloader.CachePath));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Constructor_BlankDataPath_Throws(string dataPath)
+    {
+        Assert.Throws<ArgumentException>(() => new ImdbFlatFileDownloader(
+            new StubHttpClientFactory(new StubHandler(Array.Empty<byte>())),
+            NullLogger<ImdbFlatFileDownloader>.Instance,
+            dataPath));
+    }
+
+    private static byte[] GzipOf(string content)
+    {
+        using var output = new MemoryStream();
+        using (var gzip = new GZipStream(output, CompressionLevel.Optimal, leaveOpen: true))
+        {
+            var bytes = System.Text.Encoding.UTF8.GetBytes(content);
+            gzip.Write(bytes, 0, bytes.Length);
+        }
+
+        return output.ToArray();
+    }
+
+    /// <summary>
+    /// A highly compressible payload that expands past the limit: the point of the guard is that a small
+    /// response body can still decompress into an arbitrarily large file.
+    /// </summary>
+    private static byte[] GzipOfZeroBytes(long totalBytes)
+    {
+        var chunk = new byte[1024 * 1024];
+        using var output = new MemoryStream();
+        using (var gzip = new GZipStream(output, CompressionLevel.Fastest, leaveOpen: true))
+        {
+            long written = 0;
+            while (written < totalBytes)
+            {
+                var count = (int)Math.Min(chunk.Length, totalBytes - written);
+                gzip.Write(chunk, 0, count);
+                written += count;
+            }
+        }
+
+        return output.ToArray();
+    }
+
+    private sealed class StubHttpClientFactory : IHttpClientFactory
+    {
+        private readonly HttpMessageHandler _handler;
+
+        public StubHttpClientFactory(HttpMessageHandler handler)
+        {
+            _handler = handler;
+        }
+
+        public HttpClient CreateClient(string name) => new(_handler, disposeHandler: false);
+    }
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly byte[] _body;
+        private readonly HttpStatusCode _status;
+
+        public StubHandler(byte[] body, HttpStatusCode status = HttpStatusCode.OK)
+        {
+            _body = body;
+            _status = status;
+        }
+
+        public int RequestCount { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            RequestCount++;
+            return Task.FromResult(new HttpResponseMessage(_status)
+            {
+                Content = new ByteArrayContent(_body)
+            });
+        }
+    }
+}

--- a/tests/Jellyfin.Plugin.ImdbRatings.Tests/ImdbRatingsIndexCacheTests.cs
+++ b/tests/Jellyfin.Plugin.ImdbRatings.Tests/ImdbRatingsIndexCacheTests.cs
@@ -304,29 +304,4 @@ public class ImdbRatingsIndexCacheTests
             _utcNow += amount;
         }
     }
-
-    private sealed class TempDirectory : IDisposable
-    {
-        private readonly string _path;
-
-        public TempDirectory()
-        {
-            _path = Path.Combine(Path.GetTempPath(), "imdb-ratings-cache-tests-" + Guid.NewGuid().ToString("N"));
-            Directory.CreateDirectory(_path);
-        }
-
-        public string PathFor(string fileName) => Path.Combine(_path, fileName);
-
-        public void Dispose()
-        {
-            try
-            {
-                Directory.Delete(_path, recursive: true);
-            }
-            catch
-            {
-                // Best-effort cleanup for test temp directories.
-            }
-        }
-    }
 }

--- a/tests/Jellyfin.Plugin.ImdbRatings.Tests/ImdbRatingsItemProviderTests.cs
+++ b/tests/Jellyfin.Plugin.ImdbRatings.Tests/ImdbRatingsItemProviderTests.cs
@@ -1,0 +1,240 @@
+using Jellyfin.Plugin.ImdbRatings.Configuration;
+using Jellyfin.Plugin.ImdbRatings.Providers;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Entities.TV;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Entities;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Jellyfin.Plugin.ImdbRatings.Tests;
+
+/// <summary>
+/// Covers the scan-time provider's decision ladder. Every branch here is a reason to leave an item
+/// untouched, so a regression shows up as ratings silently applied (or silently not applied) during a scan.
+/// </summary>
+public class ImdbRatingsItemProviderTests
+{
+    private const string KnownId = "tt0000001";
+    private const float KnownRating = 8.4f;
+    private const int KnownVotes = 500;
+
+    [Fact]
+    public void Apply_RatedItemWithNoExistingRating_SetsRatingAndReportsDownload()
+    {
+        var movie = MovieWith(KnownId, communityRating: null);
+
+        var result = ImdbRatingsItemProvider.Apply(movie, Config(), typeEnabled: true, Index(), NullLogger.Instance);
+
+        Assert.Equal(ItemUpdateType.MetadataDownload, result);
+        Assert.Equal(KnownRating, movie.CommunityRating!.Value, 3);
+    }
+
+    [Fact]
+    public void Apply_ProviderDisabled_LeavesItemUntouched()
+    {
+        var movie = MovieWith(KnownId, communityRating: null);
+        var config = Config();
+        config.EnableMetadataProvider = false;
+
+        var result = ImdbRatingsItemProvider.Apply(movie, config, typeEnabled: true, Index(), NullLogger.Instance);
+
+        Assert.Equal(ItemUpdateType.None, result);
+        Assert.Null(movie.CommunityRating);
+    }
+
+    [Fact]
+    public void Apply_ItemTypeDisabled_LeavesItemUntouched()
+    {
+        var movie = MovieWith(KnownId, communityRating: null);
+
+        var result = ImdbRatingsItemProvider.Apply(movie, Config(), typeEnabled: false, Index(), NullLogger.Instance);
+
+        Assert.Equal(ItemUpdateType.None, result);
+        Assert.Null(movie.CommunityRating);
+    }
+
+    [Fact]
+    public void Apply_NoIndexAvailable_LeavesItemUntouched()
+    {
+        var movie = MovieWith(KnownId, communityRating: null);
+
+        var result = ImdbRatingsItemProvider.Apply(movie, Config(), typeEnabled: true, index: null, NullLogger.Instance);
+
+        Assert.Equal(ItemUpdateType.None, result);
+        Assert.Null(movie.CommunityRating);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Apply_MissingOrBlankImdbId_LeavesItemUntouched(string? imdbId)
+    {
+        var movie = MovieWith(imdbId, communityRating: null);
+
+        var result = ImdbRatingsItemProvider.Apply(movie, Config(), typeEnabled: true, Index(), NullLogger.Instance);
+
+        Assert.Equal(ItemUpdateType.None, result);
+        Assert.Null(movie.CommunityRating);
+    }
+
+    [Fact]
+    public void Apply_ImdbIdNotInIndex_LeavesItemUntouched()
+    {
+        var movie = MovieWith("tt0000999", communityRating: null);
+
+        var result = ImdbRatingsItemProvider.Apply(movie, Config(), typeEnabled: true, Index(), NullLogger.Instance);
+
+        Assert.Equal(ItemUpdateType.None, result);
+        Assert.Null(movie.CommunityRating);
+    }
+
+    [Fact]
+    public void Apply_VotesBelowMinimum_LeavesItemUntouched()
+    {
+        var movie = MovieWith(KnownId, communityRating: null);
+        var config = Config();
+        config.MinimumVotes = KnownVotes + 1;
+
+        var result = ImdbRatingsItemProvider.Apply(movie, config, typeEnabled: true, Index(), NullLogger.Instance);
+
+        Assert.Equal(ItemUpdateType.None, result);
+        Assert.Null(movie.CommunityRating);
+    }
+
+    [Fact]
+    public void Apply_VotesExactlyAtMinimum_AppliesRating()
+    {
+        var movie = MovieWith(KnownId, communityRating: null);
+        var config = Config();
+        config.MinimumVotes = KnownVotes;
+
+        var result = ImdbRatingsItemProvider.Apply(movie, config, typeEnabled: true, Index(), NullLogger.Instance);
+
+        Assert.Equal(ItemUpdateType.MetadataDownload, result);
+    }
+
+    [Fact]
+    public void Apply_RatingAlreadyMatches_ReportsNoUpdate()
+    {
+        var movie = MovieWith(KnownId, communityRating: KnownRating);
+
+        var result = ImdbRatingsItemProvider.Apply(movie, Config(), typeEnabled: true, Index(), NullLogger.Instance);
+
+        Assert.Equal(ItemUpdateType.None, result);
+        Assert.Equal(KnownRating, movie.CommunityRating!.Value, 3);
+    }
+
+    [Fact]
+    public void Apply_RatingDiffersWithinTolerance_ReportsNoUpdateAndDoesNotRewrite()
+    {
+        // Below the shared tolerance: treating this as a change would make the provider and the scheduled
+        // task disagree and rewrite the item on every scan.
+        var almost = KnownRating - (RatingComparison.Tolerance / 2f);
+        var movie = MovieWith(KnownId, communityRating: almost);
+
+        var result = ImdbRatingsItemProvider.Apply(movie, Config(), typeEnabled: true, Index(), NullLogger.Instance);
+
+        Assert.Equal(ItemUpdateType.None, result);
+        Assert.Equal(almost, movie.CommunityRating!.Value, 4);
+    }
+
+    [Fact]
+    public void Apply_RatingDiffersByMoreThanTolerance_AppliesRating()
+    {
+        var movie = MovieWith(KnownId, communityRating: KnownRating - 0.1f);
+
+        var result = ImdbRatingsItemProvider.Apply(movie, Config(), typeEnabled: true, Index(), NullLogger.Instance);
+
+        Assert.Equal(ItemUpdateType.MetadataDownload, result);
+        Assert.Equal(KnownRating, movie.CommunityRating!.Value, 3);
+    }
+
+    [Fact]
+    public void Apply_SeriesAndEpisode_AreRatedLikeMovies()
+    {
+        var series = new Series { Name = "S" };
+        series.SetProviderId(MetadataProvider.Imdb, KnownId);
+        var episode = new Episode { Name = "E" };
+        episode.SetProviderId(MetadataProvider.Imdb, KnownId);
+
+        Assert.Equal(
+            ItemUpdateType.MetadataDownload,
+            ImdbRatingsItemProvider.Apply(series, Config(), typeEnabled: true, Index(), NullLogger.Instance));
+        Assert.Equal(
+            ItemUpdateType.MetadataDownload,
+            ImdbRatingsItemProvider.Apply(episode, Config(), typeEnabled: true, Index(), NullLogger.Instance));
+    }
+
+    [Fact]
+    public void Apply_DebugLoggingEnabled_StillAppliesRating()
+    {
+        var movie = MovieWith(KnownId, communityRating: null);
+        var config = Config();
+        config.EnableItemDebugLogging = true;
+
+        var result = ImdbRatingsItemProvider.Apply(movie, config, typeEnabled: true, Index(), NullLogger.Instance);
+
+        Assert.Equal(ItemUpdateType.MetadataDownload, result);
+        Assert.Equal(KnownRating, movie.CommunityRating!.Value, 3);
+    }
+
+    [Fact]
+    public void Apply_NullArguments_Throw()
+    {
+        var movie = MovieWith(KnownId, communityRating: null);
+
+        Assert.Throws<ArgumentNullException>(
+            () => ImdbRatingsItemProvider.Apply(null!, Config(), true, Index(), NullLogger.Instance));
+        Assert.Throws<ArgumentNullException>(
+            () => ImdbRatingsItemProvider.Apply(movie, null!, true, Index(), NullLogger.Instance));
+    }
+
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    public void TypeSelectors_MapEachItemTypeToItsOwnSetting(bool includeMovies, bool includeSeries)
+    {
+        var config = new PluginConfiguration
+        {
+            IncludeMovies = includeMovies,
+            IncludeSeries = includeSeries
+        };
+
+        Assert.Equal(includeMovies, ImdbRatingsItemProvider.IsMovieEnabled(config));
+        Assert.Equal(includeSeries, ImdbRatingsItemProvider.IsSeriesEnabled(config));
+    }
+
+    private static PluginConfiguration Config()
+    {
+        return new PluginConfiguration
+        {
+            EnableMetadataProvider = true,
+            IncludeMovies = true,
+            IncludeSeries = true,
+            MinimumVotes = 1
+        };
+    }
+
+    private static Movie MovieWith(string? imdbId, float? communityRating)
+    {
+        var movie = new Movie { Name = "Test", CommunityRating = communityRating };
+        if (imdbId is not null)
+        {
+            // Written straight into the dictionary: SetProviderId rejects blanks, so a blank IMDb ID can only
+            // reach the provider from data written by some other path. The guard under test exists for that.
+            movie.ProviderIds[MetadataProvider.Imdb.ToString()] = imdbId;
+        }
+
+        return movie;
+    }
+
+    private static ImdbRatingsIndex Index()
+    {
+        return ImdbRatingsIndex.CreateSorted(
+            new uint[] { 1 },
+            new[] { ImdbRatingsIndex.EncodeRating(KnownRating) },
+            new uint[] { KnownVotes });
+    }
+}

--- a/tests/Jellyfin.Plugin.ImdbRatings.Tests/ImdbRatingsParserValidationTests.cs
+++ b/tests/Jellyfin.Plugin.ImdbRatings.Tests/ImdbRatingsParserValidationTests.cs
@@ -1,0 +1,179 @@
+using System.Globalization;
+using System.Text;
+using Jellyfin.Plugin.ImdbRatings.Providers;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Jellyfin.Plugin.ImdbRatings.Tests;
+
+/// <summary>
+/// Covers the parser's remaining validation gates and its unfiltered entry point. These are the checks that
+/// stop a corrupt download from replacing good ratings with garbage.
+/// </summary>
+public class ImdbRatingsParserValidationTests
+{
+    // Matches ImdbRatingsParser.MinExpectedRows.
+    private const int MinExpectedRows = 500_000;
+
+    [Fact]
+    public async Task ParseAsync_WellFormedFile_ReturnsEveryRow()
+    {
+        using var temp = new TempDirectory();
+        var path = temp.PathFor("title.ratings.tsv");
+        await WriteRatingsFileAsync(path, MinExpectedRows, malformedRowCount: 0);
+
+        var parser = new ImdbRatingsParser(NullLogger<ImdbRatingsParser>.Instance);
+        var ratings = await parser.ParseAsync(path, CancellationToken.None);
+
+        Assert.Equal(MinExpectedRows, ratings.Count);
+        Assert.True(ratings.TryGetValue("tt0000001", out var first));
+        Assert.Equal(ExpectedRating(1), first.Rating, 3);
+        Assert.Equal(ExpectedVotes(1), first.Votes);
+    }
+
+    [Fact]
+    public async Task ParseAsync_ParseErrorsAboveOnePercent_RejectsTheFileAsCorrupt()
+    {
+        // Enough valid rows to clear the truncation gate, so the error-ratio gate is the one under test.
+        using var temp = new TempDirectory();
+        var path = temp.PathFor("title.ratings.tsv");
+        await WriteRatingsFileAsync(path, MinExpectedRows, malformedRowCount: 10_000);
+
+        var parser = new ImdbRatingsParser(NullLogger<ImdbRatingsParser>.Instance);
+
+        var ex = await Assert.ThrowsAsync<InvalidDataException>(
+            () => parser.ParseAsync(path, CancellationToken.None));
+
+        Assert.Contains("corrupt", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ParseAsync_ParseErrorsBelowOnePercent_AreToleratedAndSkipped()
+    {
+        using var temp = new TempDirectory();
+        var path = temp.PathFor("title.ratings.tsv");
+        await WriteRatingsFileAsync(path, MinExpectedRows, malformedRowCount: 100);
+
+        var parser = new ImdbRatingsParser(NullLogger<ImdbRatingsParser>.Instance);
+        var ratings = await parser.ParseAsync(path, CancellationToken.None);
+
+        Assert.Equal(MinExpectedRows, ratings.Count);
+    }
+
+    [Fact]
+    public async Task ParseAsync_HeaderOnly_ReportsNoDataRows()
+    {
+        using var temp = new TempDirectory();
+        var path = temp.PathFor("title.ratings.tsv");
+        await File.WriteAllTextAsync(path, "tconst\taverageRating\tnumVotes\n");
+
+        var parser = new ImdbRatingsParser(NullLogger<ImdbRatingsParser>.Instance);
+
+        var ex = await Assert.ThrowsAsync<InvalidDataException>(
+            () => parser.ParseAsync(path, CancellationToken.None));
+
+        Assert.Contains("no valid data rows", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ParseAsync_EmptyFile_ReportsMissingHeader()
+    {
+        using var temp = new TempDirectory();
+        var path = temp.PathFor("title.ratings.tsv");
+        await File.WriteAllTextAsync(path, string.Empty);
+
+        var parser = new ImdbRatingsParser(NullLogger<ImdbRatingsParser>.Instance);
+
+        var ex = await Assert.ThrowsAsync<InvalidDataException>(
+            () => parser.ParseAsync(path, CancellationToken.None));
+
+        Assert.Contains("empty file", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ParseAsync_RowLongerThanTheReadBuffer_IsStillParsed()
+    {
+        // The scanner grows its buffer when a single line does not fit in the 128 KB read buffer. Real IMDb
+        // rows are tiny, so nothing else exercises that path.
+        const int oversizedIdDigits = 200_000;
+        var longId = "tt" + new string('1', oversizedIdDigits);
+
+        using var temp = new TempDirectory();
+        var path = temp.PathFor("title.ratings.tsv");
+        await WriteRatingsFileAsync(path, MinExpectedRows, malformedRowCount: 0, extraRow: $"{longId}\t6.6\t4242");
+
+        var parser = new ImdbRatingsParser(NullLogger<ImdbRatingsParser>.Instance);
+        var ratings = await parser.ParseAsync(path, CancellationToken.None);
+
+        Assert.Equal(MinExpectedRows + 1, ratings.Count);
+        Assert.True(ratings.TryGetValue(longId, out var oversized));
+        Assert.Equal(6.6f, oversized.Rating, 3);
+        Assert.Equal(4242, oversized.Votes);
+    }
+
+    [Fact]
+    public async Task ParseFilteredAsync_NullIncludeIds_Throws()
+    {
+        using var temp = new TempDirectory();
+        var path = temp.PathFor("title.ratings.tsv");
+        await File.WriteAllTextAsync(path, "tconst\taverageRating\tnumVotes\n");
+
+        var parser = new ImdbRatingsParser(NullLogger<ImdbRatingsParser>.Instance);
+
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => parser.ParseFilteredAsync(path, null!, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task ParseAsync_Canceled_Throws()
+    {
+        using var temp = new TempDirectory();
+        var path = temp.PathFor("title.ratings.tsv");
+        await WriteRatingsFileAsync(path, 1000, malformedRowCount: 0);
+
+        var parser = new ImdbRatingsParser(NullLogger<ImdbRatingsParser>.Instance);
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => parser.ParseAsync(path, cts.Token));
+    }
+
+    private static async Task WriteRatingsFileAsync(
+        string path,
+        int validRowCount,
+        int malformedRowCount,
+        string? extraRow = null)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+
+        await using var stream = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None, 128 * 1024, useAsync: true);
+        await using var writer = new StreamWriter(stream, Encoding.ASCII);
+        writer.NewLine = "\n";
+
+        await writer.WriteLineAsync("tconst\taverageRating\tnumVotes");
+
+        for (int i = 1; i <= validRowCount; i++)
+        {
+            await writer.WriteLineAsync(string.Create(
+                CultureInfo.InvariantCulture,
+                $"tt{i:0000000}\t{ExpectedRating(i):0.0}\t{ExpectedVotes(i)}"));
+        }
+
+        // Rows the field parser rejects: a missing column and an unparseable rating.
+        for (int i = 0; i < malformedRowCount; i++)
+        {
+            await writer.WriteLineAsync(i % 2 == 0
+                ? $"tt9{i:000000}\tnot-a-rating\t100"
+                : $"tt8{i:000000}\tmissing-second-tab");
+        }
+
+        if (extraRow is not null)
+        {
+            await writer.WriteLineAsync(extraRow);
+        }
+    }
+
+    private static float ExpectedRating(int index) => ((index % 90) + 10) / 10f;
+
+    private static int ExpectedVotes(int index) => 1000 + index;
+}

--- a/tests/Jellyfin.Plugin.ImdbRatings.Tests/RatingComparisonTests.cs
+++ b/tests/Jellyfin.Plugin.ImdbRatings.Tests/RatingComparisonTests.cs
@@ -1,0 +1,72 @@
+using Jellyfin.Plugin.ImdbRatings.Providers;
+
+namespace Jellyfin.Plugin.ImdbRatings.Tests;
+
+/// <summary>
+/// The scheduled task and the scan-time provider both decide "has this rating changed?", and they must give
+/// the same answer. If they diverge, an item's rating is rewritten by whichever path runs last, forever.
+/// </summary>
+public class RatingComparisonTests
+{
+    [Fact]
+    public void IsUnchanged_NoExistingRating_IsAlwaysAChange()
+    {
+        Assert.False(RatingComparison.IsUnchanged(null, 7.4f));
+    }
+
+    [Fact]
+    public void IsUnchanged_IdenticalRating_IsUnchanged()
+    {
+        Assert.True(RatingComparison.IsUnchanged(7.4f, 7.4f));
+    }
+
+    [Theory]
+    [InlineData(0.0f)]
+    [InlineData(0.001f)]
+    [InlineData(0.009f)]
+    public void IsUnchanged_DifferenceBelowTolerance_IsUnchanged(float delta)
+    {
+        Assert.True(RatingComparison.IsUnchanged(7.4f, 7.4f + delta));
+        Assert.True(RatingComparison.IsUnchanged(7.4f, 7.4f - delta));
+    }
+
+    [Theory]
+    [InlineData(0.1f)]
+    [InlineData(0.5f)]
+    [InlineData(3.0f)]
+    public void IsUnchanged_DifferenceAboveTolerance_IsAChange(float delta)
+    {
+        Assert.False(RatingComparison.IsUnchanged(7.4f, 7.4f + delta));
+        Assert.False(RatingComparison.IsUnchanged(7.4f, 7.4f - delta));
+    }
+
+    [Fact]
+    public void IsUnchanged_DifferenceExactlyAtTolerance_IsAChange()
+    {
+        // Strictly-less-than, so the boundary itself counts as a change.
+        Assert.False(RatingComparison.IsUnchanged(7.4f, 7.4f + RatingComparison.Tolerance));
+    }
+
+    [Fact]
+    public void Tolerance_IsTighterThanTheSmallestRatingImdbPublishes()
+    {
+        // IMDb publishes one decimal place, so every real change is at least 0.1.
+        Assert.True(RatingComparison.Tolerance < 0.1f);
+    }
+
+    [Fact]
+    public void IsUnchanged_SurvivesTheIndexRoundTrip()
+    {
+        // A rating that went through the byte-encoded index must compare equal to its source value, or the
+        // provider would rewrite every item on every scan.
+        for (int scaled = 10; scaled <= 100; scaled++)
+        {
+            var original = scaled / 10f;
+            var roundTripped = ImdbRatingsIndex.EncodeRating(original) / 10f;
+
+            Assert.True(
+                RatingComparison.IsUnchanged(original, roundTripped),
+                $"Rating {original} did not survive the index round trip");
+        }
+    }
+}

--- a/tests/Jellyfin.Plugin.ImdbRatings.Tests/RefreshImdbRatingsTaskMetadataTests.cs
+++ b/tests/Jellyfin.Plugin.ImdbRatings.Tests/RefreshImdbRatingsTaskMetadataTests.cs
@@ -1,0 +1,92 @@
+using Jellyfin.Plugin.ImdbRatings.ScheduledTasks;
+using MediaBrowser.Common.Configuration;
+using MediaBrowser.Model.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Jellyfin.Plugin.ImdbRatings.Tests;
+
+/// <summary>
+/// Covers the task's registration surface: the schedule Jellyfin reads when the plugin is first installed.
+/// </summary>
+public class RefreshImdbRatingsTaskMetadataTests
+{
+    [Fact]
+    public void GetDefaultTriggers_IsASingleDailyTriggerAtThreeAm()
+    {
+        var trigger = Assert.Single(CreateTask().GetDefaultTriggers());
+
+        Assert.Equal(TaskTriggerInfoType.DailyTrigger, trigger.Type);
+        Assert.Equal(TimeSpan.FromHours(3).Ticks, trigger.TimeOfDayTicks);
+    }
+
+    [Fact]
+    public void TaskIdentity_IsStable()
+    {
+        var task = CreateTask();
+
+        // The key is what Jellyfin persists against a user's saved schedule; changing it silently resets it.
+        Assert.Equal("RefreshImdbRatings", task.Key);
+        Assert.Equal("Refresh IMDb Ratings", task.Name);
+        Assert.Equal("IMDb Ratings", task.Category);
+        Assert.False(string.IsNullOrWhiteSpace(task.Description));
+    }
+
+    private static RefreshImdbRatingsTask CreateTask()
+    {
+        using var temp = new TempDirectory();
+
+        // Only DataPath is read by the constructor; nothing here reaches the library or the network.
+        return new RefreshImdbRatingsTask(
+            libraryManager: null!,
+            httpClientFactory: null!,
+            NullLogger<RefreshImdbRatingsTask>.Instance,
+            NullLoggerFactory.Instance,
+            new StubApplicationPaths(temp.Path));
+    }
+
+    private sealed class StubApplicationPaths : IApplicationPaths
+    {
+        public StubApplicationPaths(string dataPath)
+        {
+            DataPath = dataPath;
+        }
+
+        public string DataPath { get; }
+
+        public string ProgramDataPath => DataPath;
+
+        public string WebPath => DataPath;
+
+        public string ProgramSystemPath => DataPath;
+
+        public string ImageCachePath => DataPath;
+
+        public string PluginsPath => DataPath;
+
+        public string PluginConfigurationsPath => DataPath;
+
+        public string LogDirectoryPath => DataPath;
+
+        public string ConfigurationDirectoryPath => DataPath;
+
+        public string SystemConfigurationFilePath => DataPath;
+
+        public string CachePath => DataPath;
+
+        public string TempDirectory => DataPath;
+
+        public string VirtualDataPath => DataPath;
+
+        public string TrickplayPath => DataPath;
+
+        public string BackupPath => DataPath;
+
+        public void MakeSanityCheckOrThrow()
+        {
+        }
+
+        public void CreateAndCheckMarker(string path, string markerName, bool recursive)
+        {
+        }
+    }
+}

--- a/tests/Jellyfin.Plugin.ImdbRatings.Tests/RefreshImdbRatingsTaskSaveTests.cs
+++ b/tests/Jellyfin.Plugin.ImdbRatings.Tests/RefreshImdbRatingsTaskSaveTests.cs
@@ -1,0 +1,313 @@
+using Jellyfin.Data.Enums;
+using Jellyfin.Plugin.ImdbRatings.Configuration;
+using Jellyfin.Plugin.ImdbRatings.ScheduledTasks;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Entities;
+
+namespace Jellyfin.Plugin.ImdbRatings.Tests;
+
+/// <summary>
+/// Covers the batch-save loop, whose defining behaviour is that a failed save must leave no trace in memory.
+/// Jellyfin hands out live item instances, so a rating that was applied but not persisted would be visible
+/// in the running server until restart while no database row backs it.
+/// </summary>
+public class RefreshImdbRatingsTaskSaveTests
+{
+    [Fact]
+    public async Task ApplyPendingUpdatesAsync_Success_AppliesEveryRatingAndSavesOnce()
+    {
+        var parent = Folder("parent");
+        var first = MovieWith(6.0f);
+        var second = MovieWith(null);
+        var updates = new[]
+        {
+            new RefreshImdbRatingsTask.PendingRatingUpdate(first, parent, first.CommunityRating, 8.1f),
+            new RefreshImdbRatingsTask.PendingRatingUpdate(second, parent, second.CommunityRating, 7.2f)
+        };
+        var sink = new RecordingSink();
+
+        await RefreshImdbRatingsTask.ApplyPendingUpdatesAsync(updates, sink, new NoopProgress(), CancellationToken.None);
+
+        Assert.Equal(8.1f, first.CommunityRating!.Value, 3);
+        Assert.Equal(7.2f, second.CommunityRating!.Value, 3);
+        Assert.Single(sink.BatchCalls);
+        Assert.Equal(2, sink.BatchCalls[0].Items.Count);
+        Assert.Same(parent, sink.BatchCalls[0].Parent);
+        Assert.Equal(ItemUpdateType.MetadataEdit, sink.BatchCalls[0].UpdateReason);
+    }
+
+    [Fact]
+    public async Task ApplyPendingUpdatesAsync_BatchSaveThrows_RevertsEveryRatingInThatChunk()
+    {
+        var parent = Folder("parent");
+        var withPrevious = MovieWith(6.0f);
+        var withoutPrevious = MovieWith(null);
+        var updates = new[]
+        {
+            new RefreshImdbRatingsTask.PendingRatingUpdate(withPrevious, parent, withPrevious.CommunityRating, 8.1f),
+            new RefreshImdbRatingsTask.PendingRatingUpdate(withoutPrevious, parent, withoutPrevious.CommunityRating, 7.2f)
+        };
+        var sink = new RecordingSink { BatchFailure = () => new InvalidOperationException("database is locked") };
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => RefreshImdbRatingsTask.ApplyPendingUpdatesAsync(updates, sink, new NoopProgress(), CancellationToken.None));
+
+        Assert.Equal(6.0f, withPrevious.CommunityRating!.Value, 3);
+        Assert.Null(withoutPrevious.CommunityRating);
+    }
+
+    [Fact]
+    public async Task ApplyPendingUpdatesAsync_BatchSaveCanceled_RevertsEveryRatingInThatChunk()
+    {
+        var parent = Folder("parent");
+        var movie = MovieWith(6.0f);
+        var updates = new[]
+        {
+            new RefreshImdbRatingsTask.PendingRatingUpdate(movie, parent, movie.CommunityRating, 8.1f)
+        };
+        var sink = new RecordingSink { BatchFailure = () => new OperationCanceledException() };
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => RefreshImdbRatingsTask.ApplyPendingUpdatesAsync(updates, sink, new NoopProgress(), CancellationToken.None));
+
+        Assert.Equal(6.0f, movie.CommunityRating!.Value, 3);
+    }
+
+    [Fact]
+    public async Task ApplyPendingUpdatesAsync_LaterChunkFails_EarlierSavedChunksKeepTheirRatings()
+    {
+        // 501 items under one parent split into chunks of 500 and 1; only the second chunk fails.
+        var parent = Folder("parent");
+        var updates = new List<RefreshImdbRatingsTask.PendingRatingUpdate>();
+        for (int i = 0; i < 501; i++)
+        {
+            var movie = MovieWith(1.0f);
+            updates.Add(new RefreshImdbRatingsTask.PendingRatingUpdate(movie, parent, movie.CommunityRating, 9.0f));
+        }
+
+        var sink = new RecordingSink { FailBatchAtCall = 2, BatchFailure = () => new InvalidOperationException("boom") };
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => RefreshImdbRatingsTask.ApplyPendingUpdatesAsync(updates, sink, new NoopProgress(), CancellationToken.None));
+
+        // First chunk persisted, so its in-memory ratings stand.
+        for (int i = 0; i < 500; i++)
+        {
+            Assert.Equal(9.0f, updates[i].Item.CommunityRating!.Value, 3);
+        }
+
+        // The failed chunk is rolled back.
+        Assert.Equal(1.0f, updates[500].Item.CommunityRating!.Value, 3);
+    }
+
+    [Fact]
+    public async Task ApplyPendingUpdatesAsync_ChunksAtFiveHundredPerSave()
+    {
+        var parent = Folder("parent");
+        var updates = new List<RefreshImdbRatingsTask.PendingRatingUpdate>();
+        for (int i = 0; i < 1200; i++)
+        {
+            var movie = MovieWith(null);
+            updates.Add(new RefreshImdbRatingsTask.PendingRatingUpdate(movie, parent, null, 7.0f));
+        }
+
+        var sink = new RecordingSink();
+
+        await RefreshImdbRatingsTask.ApplyPendingUpdatesAsync(updates, sink, new NoopProgress(), CancellationToken.None);
+
+        Assert.Equal(new[] { 500, 500, 200 }, sink.BatchCalls.Select(c => c.Items.Count).ToArray());
+    }
+
+    [Fact]
+    public async Task ApplyPendingUpdatesAsync_ItemsUnderDifferentParents_AreSavedSeparately()
+    {
+        var firstParent = Folder("a");
+        var secondParent = Folder("b");
+        var underFirst = MovieWith(null);
+        var underSecond = MovieWith(null);
+        var updates = new[]
+        {
+            new RefreshImdbRatingsTask.PendingRatingUpdate(underFirst, firstParent, null, 7.0f),
+            new RefreshImdbRatingsTask.PendingRatingUpdate(underSecond, secondParent, null, 8.0f)
+        };
+        var sink = new RecordingSink();
+
+        await RefreshImdbRatingsTask.ApplyPendingUpdatesAsync(updates, sink, new NoopProgress(), CancellationToken.None);
+
+        Assert.Equal(2, sink.BatchCalls.Count);
+        Assert.Contains(sink.BatchCalls, c => ReferenceEquals(c.Parent, firstParent));
+        Assert.Contains(sink.BatchCalls, c => ReferenceEquals(c.Parent, secondParent));
+    }
+
+    [Fact]
+    public async Task ApplyPendingUpdatesAsync_NullParent_SavesItemsIndividually()
+    {
+        var first = MovieWith(null);
+        var second = MovieWith(null);
+        var updates = new[]
+        {
+            new RefreshImdbRatingsTask.PendingRatingUpdate(first, null, null, 7.0f),
+            new RefreshImdbRatingsTask.PendingRatingUpdate(second, null, null, 8.0f)
+        };
+        var sink = new RecordingSink();
+
+        await RefreshImdbRatingsTask.ApplyPendingUpdatesAsync(updates, sink, new NoopProgress(), CancellationToken.None);
+
+        Assert.Equal(2, sink.SingleCalls.Count);
+        Assert.Empty(sink.BatchCalls);
+        Assert.Equal(7.0f, first.CommunityRating!.Value, 3);
+        Assert.Equal(8.0f, second.CommunityRating!.Value, 3);
+    }
+
+    [Fact]
+    public async Task ApplyPendingUpdatesAsync_NullParentSaveThrows_RevertsOnlyTheFailedItem()
+    {
+        var saved = MovieWith(2.0f);
+        var failed = MovieWith(3.0f);
+        var updates = new[]
+        {
+            new RefreshImdbRatingsTask.PendingRatingUpdate(saved, null, saved.CommunityRating, 7.0f),
+            new RefreshImdbRatingsTask.PendingRatingUpdate(failed, null, failed.CommunityRating, 8.0f)
+        };
+        var sink = new RecordingSink { FailSingleAtCall = 2, SingleFailure = () => new InvalidOperationException("boom") };
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => RefreshImdbRatingsTask.ApplyPendingUpdatesAsync(updates, sink, new NoopProgress(), CancellationToken.None));
+
+        Assert.Equal(7.0f, saved.CommunityRating!.Value, 3);
+        Assert.Equal(3.0f, failed.CommunityRating!.Value, 3);
+    }
+
+    [Fact]
+    public async Task ApplyPendingUpdatesAsync_AlreadyCanceled_SavesNothingAndMutatesNothing()
+    {
+        var parent = Folder("parent");
+        var movie = MovieWith(4.0f);
+        var updates = new[]
+        {
+            new RefreshImdbRatingsTask.PendingRatingUpdate(movie, parent, movie.CommunityRating, 9.0f)
+        };
+        var sink = new RecordingSink();
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => RefreshImdbRatingsTask.ApplyPendingUpdatesAsync(updates, sink, new NoopProgress(), cts.Token));
+
+        Assert.Equal(4.0f, movie.CommunityRating!.Value, 3);
+        Assert.Empty(sink.BatchCalls);
+    }
+
+    [Fact]
+    public async Task ApplyPendingUpdatesAsync_ReportsProgressBetweenNinetyAndOneHundred()
+    {
+        var parent = Folder("parent");
+        var updates = new List<RefreshImdbRatingsTask.PendingRatingUpdate>();
+        for (int i = 0; i < 1200; i++)
+        {
+            var movie = MovieWith(null);
+            updates.Add(new RefreshImdbRatingsTask.PendingRatingUpdate(movie, parent, null, 7.0f));
+        }
+
+        var progress = new RecordingProgress();
+
+        await RefreshImdbRatingsTask.ApplyPendingUpdatesAsync(updates, new RecordingSink(), progress, CancellationToken.None);
+
+        Assert.NotEmpty(progress.Reports);
+        Assert.All(progress.Reports, value => Assert.InRange(value, 90.0, 100.0));
+        Assert.Equal(100.0, progress.Reports[^1], 3);
+    }
+
+    [Fact]
+    public async Task ApplyPendingUpdatesAsync_NullArguments_Throw()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => RefreshImdbRatingsTask.ApplyPendingUpdatesAsync(null!, new RecordingSink(), new NoopProgress(), CancellationToken.None));
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => RefreshImdbRatingsTask.ApplyPendingUpdatesAsync(Array.Empty<RefreshImdbRatingsTask.PendingRatingUpdate>(), null!, new NoopProgress(), CancellationToken.None));
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => RefreshImdbRatingsTask.ApplyPendingUpdatesAsync(Array.Empty<RefreshImdbRatingsTask.PendingRatingUpdate>(), new RecordingSink(), null!, CancellationToken.None));
+    }
+
+    [Theory]
+    [InlineData(true, true, new[] { BaseItemKind.Movie, BaseItemKind.Series, BaseItemKind.Episode })]
+    [InlineData(true, false, new[] { BaseItemKind.Movie })]
+    [InlineData(false, true, new[] { BaseItemKind.Series, BaseItemKind.Episode })]
+    public void BuildIncludeItemTypes_SelectsTypesForEachToggle(bool movies, bool series, BaseItemKind[] expected)
+    {
+        var config = new PluginConfiguration { IncludeMovies = movies, IncludeSeries = series };
+
+        Assert.Equal(expected, RefreshImdbRatingsTask.BuildIncludeItemTypes(config));
+    }
+
+    [Fact]
+    public void BuildIncludeItemTypes_NothingSelected_ReturnsEmptySoTheLibraryIsNeverQueried()
+    {
+        var config = new PluginConfiguration { IncludeMovies = false, IncludeSeries = false };
+
+        Assert.Empty(RefreshImdbRatingsTask.BuildIncludeItemTypes(config));
+    }
+
+    private static Movie MovieWith(float? communityRating)
+    {
+        var movie = new Movie { Name = "Test", Id = Guid.NewGuid(), CommunityRating = communityRating };
+        movie.ProviderIds[MetadataProvider.Imdb.ToString()] = "tt0000001";
+        return movie;
+    }
+
+    private static Folder Folder(string name) => new() { Name = name, Id = Guid.NewGuid() };
+
+    private sealed class RecordingSink : RefreshImdbRatingsTask.IItemUpdateSink
+    {
+        public List<(IReadOnlyList<BaseItem> Items, BaseItem Parent, ItemUpdateType UpdateReason)> BatchCalls { get; } = new();
+
+        public List<(BaseItem Item, BaseItem? Parent, ItemUpdateType UpdateReason)> SingleCalls { get; } = new();
+
+        public Func<Exception>? BatchFailure { get; set; }
+
+        public Func<Exception>? SingleFailure { get; set; }
+
+        /// <summary>Gets or sets the 1-based batch call that should fail; 0 fails the first when a failure is set.</summary>
+        public int FailBatchAtCall { get; set; }
+
+        public int FailSingleAtCall { get; set; }
+
+        public Task UpdateItemAsync(BaseItem item, BaseItem? parent, ItemUpdateType updateReason, CancellationToken cancellationToken)
+        {
+            SingleCalls.Add((item, parent, updateReason));
+            if (SingleFailure is not null && (FailSingleAtCall == 0 || SingleCalls.Count == FailSingleAtCall))
+            {
+                throw SingleFailure();
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task UpdateItemsAsync(IReadOnlyList<BaseItem> items, BaseItem parent, ItemUpdateType updateReason, CancellationToken cancellationToken)
+        {
+            BatchCalls.Add((items.ToArray(), parent, updateReason));
+            if (BatchFailure is not null && (FailBatchAtCall == 0 || BatchCalls.Count == FailBatchAtCall))
+            {
+                throw BatchFailure();
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class RecordingProgress : IProgress<double>
+    {
+        public List<double> Reports { get; } = new();
+
+        public void Report(double value) => Reports.Add(value);
+    }
+
+    private sealed class NoopProgress : IProgress<double>
+    {
+        public void Report(double value)
+        {
+        }
+    }
+}

--- a/tests/Jellyfin.Plugin.ImdbRatings.Tests/TempDirectory.cs
+++ b/tests/Jellyfin.Plugin.ImdbRatings.Tests/TempDirectory.cs
@@ -1,0 +1,36 @@
+namespace Jellyfin.Plugin.ImdbRatings.Tests;
+
+/// <summary>
+/// A throwaway directory for tests that touch the filesystem, removed on dispose.
+/// </summary>
+internal sealed class TempDirectory : IDisposable
+{
+    private readonly string _path;
+
+    public TempDirectory()
+    {
+        _path = System.IO.Path.Combine(
+            System.IO.Path.GetTempPath(),
+            "imdb-ratings-cache-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_path);
+    }
+
+    /// <summary>
+    /// Gets the directory itself, for callers that need a data path rather than a file inside it.
+    /// </summary>
+    public string Path => _path;
+
+    public string PathFor(string fileName) => System.IO.Path.Combine(_path, fileName);
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_path, recursive: true);
+        }
+        catch
+        {
+            // Best-effort cleanup for test temp directories.
+        }
+    }
+}


### PR DESCRIPTION
Raises line coverage from **48.1% to 64.7%** (68 → 135 tests, all passing) by covering the three areas that had none, and corrects both README badges.

## Tests

| Area | Was | Why it matters |
|---|---|---|
| `ImdbRatingsItemProvider` decision ladder | 0% | Newest feature (65751c9) shipped with no tests; 7 branches, each a reason to leave an item untouched |
| `ImdbFlatFileDownloader` | 0% | Includes the 100 MB decompressed-size guard — a security control on network-fetched gzip — plus temp cleanup on failure and cache freshness at the 23h boundary |
| Batch-save rollback | 0% | Jellyfin hands out live `BaseItem` instances, so a chunk that failed to persist must not leave the running server showing a rating no database row holds |
| Parser gaps | partial | The >1% parse-error ratio gate, the unfiltered `ParseAsync` entry point, and the buffer-growth path for a line larger than the 128 KB read buffer |

Per-file after: parser 94.9%, index 89.3%, downloader 82.8%, cache 81.2%, `RatingComparison` / `SeasonRatingCalculator` / `PluginConfiguration` 100%.

## Production changes

All four are seams needed to make the above testable. Behaviour is unchanged; **no new test dependencies** (hand-rolled stubs rather than adding a mocking library).

- **`Providers/RatingComparison.cs` (new)** — holds the `0.01f` "has this rating changed?" tolerance. It was duplicated in `ImdbRatingsItemProvider` and `RefreshImdbRatingsTask` with only a comment saying the two must agree. If they drifted, an item's rating would be rewritten by whichever path ran last, on every refresh, forever. Now one shared function instead of a documented invariant.
- **`ImdbRatingsItemProvider.Apply`** — extracted as `internal static` taking config and index as parameters, so the ladder is testable without the `Plugin.Instance` singleton (null under test, which is why this class had no tests). Type selectors became named methods so the item-type→setting mapping is locked down.
- **`RefreshImdbRatingsTask.ApplyPendingUpdatesAsync`** — save loop extracted behind a two-method `internal interface IItemUpdateSink`, rather than stubbing all 105 members of `ILibraryManager`. Loop body moved verbatim.
- **`BuildIncludeItemTypes`** — pulled out of private `GetLibraryItems` as a pure function.

## Dependabot

Adds an entry for `/tests/Jellyfin.Plugin.ImdbRatings.Tests`. The test project sits outside the root csproj's `ProjectReference` graph and there's no solution file, so Dependabot has never seen it — which is why its four packages are far behind while the Jellyfin ones are current. Expect four PRs on the next run; `xunit.runner.visualstudio` 2.8.2 → 4.0.0 and `coverlet.collector` 6.0.4 → 10.0.1 are major jumps worth a look rather than a blind merge.

No `ignore` rule was added for `Jellyfin.*` — those PRs stay as the new-release signal.

## Badges

Both are hand-maintained with nothing recalculating them, and both had drifted. Coverage 26% → 65%. Dependencies stays at 4, now correct for the right reason (it counts only actionable updates, excluding the deliberately pinned `Jellyfin.*` refs) rather than by coincidence. `CONTRIBUTING.md` gains a `## Badges` section with one sentence per badge so the next person knows how to recompute them.

## Behaviour noted, not changed

A gzip response that ends mid-header doesn't throw — `GZipStream` treats it as clean EOF, so the downloader writes an **empty cache file** and reports success. It's caught one layer up (parser rejects it, task invalidates and re-downloads), so it isn't data corruption, but it does mean a truncated response destroys a previously-good cache. The test asserts and documents current behaviour rather than silently changing it: `GetRatingsFilePathAsync_TruncatedGzipHeader_WritesEmptyCacheForTheParserToReject`. Tightening it is a separate call.

## Still uncovered, deliberately

`ExecuteAsync` (the 446-line orchestrator) and `Plugin.cs` remain at 0% — both need a real `ILibraryManager` or a live `BasePlugin`, which is integration territory. That's most of why `RefreshImdbRatingsTask.cs` still reads 27.4% as a file even though everything extracted from it is covered.

---

Release build clean, both `dotnet format` lint checks pass.