### PR TITLE
docs(readme): dependencies badge 4 -> 2 outdated

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
     <img src="https://img.shields.io/github/license/voc0der/jellyfin-imdb-rating-updater?color=97CA00" alt="License" />
   </a>
   <a href="https://github.com/voc0der/jellyfin-imdb-rating-updater/network/dependencies">
-    <img src="https://img.shields.io/badge/dependencies-4%20outdated-orange" alt="Dependencies status" />
+    <img src="https://img.shields.io/badge/dependencies-2%20outdated-orange" alt="Dependencies status" />
   </a>
 </p>
 


### PR DESCRIPTION
Follow-up to #32 and #29, which bumped `Microsoft.NET.Test.Sdk` and `coverlet.collector`.

Per the rule in `CONTRIBUTING.md` — count `dotnet list package --outdated` across both projects, excluding the deliberately pinned `Jellyfin.*` refs — the actionable count is now **2**:

| Package | Current | Latest |
|---|---|---|
| `xunit` | 2.9.0 | 2.9.3 |
| `xunit.runner.visualstudio` | 2.8.2 | 4.0.0 |

`Jellyfin.Controller` / `Jellyfin.Model` remain at 10.11.8 by design and are excluded from the count.

Coverage badge unchanged at 65% — verified the coverlet 6.0.4 → 10.0.1 bump reports the same line-rate (64.71%), and the full suite passes 135/135 on the updated dependencies.